### PR TITLE
Thread name

### DIFF
--- a/doc/logs_doc.doxy
+++ b/doc/logs_doc.doxy
@@ -277,14 +277,14 @@
  *
  * @param[in]  id    The identifier returned by std::thread::get_id()
  * @param[in]  name  Name that should be displayed instead of an id
- * @see mlog::Options::unbidThreadName
+ * @see mlog::Options::unbindThreadName
  * 
- * @fn void mlog::Options::unbidThreadName(const std::thread::id& id)
+ * @fn void mlog::Options::unbindThreadName(const std::thread::id& id)
  * Unbinds the thread id if it exists. This way, using the {THREAD}
  * tag will print the thread id
  *
  * @param[in]  id    The identifier returned by std::thread::get_id()
- * @see mlog::Options::bidThreadName
+ * @see mlog::Options::bindThreadName
  */
 
 // Developpers part, enable HIDE_THIS_DOXYGEN to see it
@@ -429,7 +429,7 @@
  * @var mlog::__details::__Static_declarer::THREAD_NAME
  * The container for bounds between thread id and a string value
  * @see mlog::Options::bindThreadName
- * @see mlog::Options::unbidThreadName
+ * @see mlog::Options::unbindThreadName
  * 
  * @var mlog::__details::__Static_declarer::MUTEX
  * A mutex to guaranty mutual exclusion for logging.

--- a/doc/logs_doc.doxy
+++ b/doc/logs_doc.doxy
@@ -270,6 +270,21 @@
  *   - {TYPE}   To display here the type of the log.
  *   - {DATE}   To display here the date of the log.
  *   - {THREAD} To display here the emiter thread number (only if -pthread or -fopenmp).
+ * 
+ * @fn void mlog::Options::bindThreadName(const std::thread::id& id, const std::string& name)
+ * Binds the thread id to the name so that when using the tag
+ * {THREAD} the name given is used instead of an hexadecimal output
+ *
+ * @param[in]  id    The identifier returned by std::thread::get_id()
+ * @param[in]  name  Name that should be displayed instead of an id
+ * @see mlog::Options::unbidThreadName
+ * 
+ * @fn void mlog::Options::unbidThreadName(const std::thread::id& id)
+ * Unbinds the thread id if it exists. This way, using the {THREAD}
+ * tag will print the thread id
+ *
+ * @param[in]  id    The identifier returned by std::thread::get_id()
+ * @see mlog::Options::bidThreadName
  */
 
 // Developpers part, enable HIDE_THIS_DOXYGEN to see it
@@ -410,6 +425,11 @@
  * 
  * @var mlog::__details::__Static_declarer::FORMAT
  * The header format (<b>"[{TYPE} {DATE}] : "</b> by default).
+ * 
+ * @var mlog::__details::__Static_declarer::THREAD_NAME
+ * The container for bounds between thread id and a string value
+ * @see mlog::Options::bindThreadName
+ * @see mlog::Options::unbidThreadName
  * 
  * @var mlog::__details::__Static_declarer::MUTEX
  * A mutex to guaranty mutual exclusion for logging.

--- a/logs.hpp
+++ b/logs.hpp
@@ -293,11 +293,11 @@ namespace MTL_LOG_NAMESPACE
                 return MTL_LOG_NAMESPACE::Options::FORMAT;
             }
 #           ifdef _REENTRANT
-            static void addThreadName(const std::thread::id& id, const std::string& name)
+            static void bindThreadName(const std::thread::id& id, const std::string& name)
             {
                 MTL_LOG_NAMESPACE::Options::THREAD_NAME.insert(std::make_pair(id, name));
             }
-            static void delThreadName(const std::thread::id& id)
+            static void unbidThreadName(const std::thread::id& id)
             {
                 MTL_LOG_NAMESPACE::Options::THREAD_NAME.erase(id);
             }

--- a/logs.hpp
+++ b/logs.hpp
@@ -4,17 +4,14 @@
 #include <chrono>
 #include <ctime>
 #include <fstream>
-#include <sstream>
 #include <iostream>
 #include <string>
 #include <utility>
 #include <vector>
+#include <map>
 
 // if -pthread or -fopenmp provided only
 #ifdef _REENTRANT
-#   define MTL_LOG_WITH_THREADS
-#endif
-#ifdef MTL_LOG_WITH_THREADS
 #   include <thread>
 #   include <mutex>
 #endif
@@ -37,7 +34,6 @@
 #   endif
 #endif
 
-#define MTL_LOG_VARIABLE(varname) #varname " =", varname
 
 namespace MTL_LOG_NAMESPACE
 {
@@ -48,8 +44,7 @@ namespace MTL_LOG_NAMESPACE
     MTL_LOG_DECLARE(error)
     MTL_LOG_DECLARE(fatal)
     MTL_LOG_DECLARE(debug)
-    MTL_LOG_DECLARE(trace)
-    inline DECLSPEC bool loadConfiguration(const std::string& fname);
+    inline DECLSPEC void loadConfiguration(const std::string& fname);
 #   undef MTL_LOG_DECLARE
     
     namespace __details
@@ -62,8 +57,7 @@ namespace MTL_LOG_NAMESPACE
             MTL_LOG_FRIEND(warning) \
             MTL_LOG_FRIEND(error) \
             MTL_LOG_FRIEND(fatal) \
-            MTL_LOG_FRIEND(debug) \
-            MTL_LOG_FRIEND(trace)
+            MTL_LOG_FRIEND(debug)
         
         class __Header final
         {
@@ -80,41 +74,41 @@ namespace MTL_LOG_NAMESPACE
                     return *this;
                 }
                 ~__Header(void) = default;
-                operator std::string(void)
-                {
-                    return this->pattern;
-                }
                 void display(std::ostream& out, const std::string& type, const char *const color,
-                             const char *const nocolor, bool colorEnabled)
+                             const char *const nocolor, bool colorEnabled, const void* threads_names)
                 {
-                    for(const auto& p : this->chunks)
+#                   ifdef _REENTRANT
+                    const std::map<std::thread::id, std::string>* thread = reinterpret_cast<const std::map<std::thread::id, std::string>*>(threads_names);
+#                   endif
+                    for(const std::pair<int, int>& p : this->chunks)
                     {
                         switch(p.first)
                         {
-                            case -1:
+                            case MTL_LOG_NAMESPACE::__details::__Header::TAG_DATE_ID:
                             {
                                 time_t  tt  = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
                                 std::tm ltm = *localtime(&tt);
                                 this->printTwoDigits(out, ltm.tm_mon+1) << '/';
                                 this->printTwoDigits(out, ltm.tm_mday)  << '/';
-                                out << ltm.tm_year + 1900;
-                                break;
-                            }
-                            case -4:
-                            {
-                                time_t  tt  = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-                                std::tm ltm = *localtime(&tt);
+                                out << ltm.tm_year + 1900 << ' ';
                                 this->printTwoDigits(out, ltm.tm_hour) << ':';
                                 this->printTwoDigits(out, ltm.tm_min) << ':';
                                 this->printTwoDigits(out, ltm.tm_sec);
                                 break;
                             }
-                            case -3:
-#                               ifdef MTL_LOG_WITH_THREADS
-                                out << "0x" << std::hex << std::this_thread::get_id() << std::dec;
+                            case MTL_LOG_NAMESPACE::__details::__Header::TAG_THREAD_ID:
+#                               ifdef _REENTRANT
+                                try
+                                {
+                                    out << (*thread).at(std::this_thread::get_id());
+                                }
+                                catch (const std::out_of_range&)
+                                {
+                                    out << "0x" << std::hex << std::this_thread::get_id() << std::dec;
+                                }
 #                               endif
                                 break;
-                            case -2:
+                            case MTL_LOG_NAMESPACE::__details::__Header::TAG_TYPE_ID:
                                 if (colorEnabled)
                                 {
                                     out << color;
@@ -134,15 +128,23 @@ namespace MTL_LOG_NAMESPACE
                     }
                 }
             private:
+                static constexpr const int         TAG_DATE_ID    = -1;
+                static constexpr const int         TAG_TYPE_ID    = -2;
+                static constexpr const int         TAG_THREAD_ID  = -3;
+                static constexpr const char *const TAG_TYPE       = "{TYPE}";
+                static constexpr const char *const TAG_THREAD     = "{THREAD}";
+                static constexpr const char *const TAG_DATE       = "{DATE}";
                 std::string                      pattern;
                 std::vector<std::pair<int, int>> chunks;
                 inline std::ostream& printTwoDigits(std::ostream& out, int value)
                 {
-                    return out << ((value < 10) ? "0" : "") << value;
+                    out << ((value < 10) ? "0" : "") << value;
+                    return out;
                 }
                 void splitAndMerge(int begin, int end, int id)
                 {
-                    for(auto it=this->chunks.begin();it!=this->chunks.end();++it)
+                    auto it=this->chunks.begin();
+                    for(;it!=this->chunks.end();++it)
                     {
                         if (it->second > begin)
                         {
@@ -155,52 +157,54 @@ namespace MTL_LOG_NAMESPACE
                         }
                     }
                 }
-                void checkAndMergeIfFound(const std::string& tag, int id)
-                {
-                    std::size_t pos = this->pattern.find(tag);
-                    if (pos != std::string::npos)
-                    {
-                        this->splitAndMerge(static_cast<int>(pos), static_cast<int>(tag.length()), id);
+#               define SPLIT_AND_MERGE(var, tag, id) \
+                    if (var != std::string::npos)\
+                    {\
+                        this->splitAndMerge(static_cast<int>(var),\
+                            static_cast<int>(std::string(MTL_LOG_NAMESPACE::__details::__Header::tag).length()), id);\
                     }
-                }
                 void build(void)
                 {
                     this->chunks.clear();
+                    std::size_t typePos    = this->pattern.find(MTL_LOG_NAMESPACE::__details::__Header::TAG_TYPE);
+                    std::size_t threadPos  = this->pattern.find(MTL_LOG_NAMESPACE::__details::__Header::TAG_THREAD);
+                    std::size_t datePos    = this->pattern.find(MTL_LOG_NAMESPACE::__details::__Header::TAG_DATE);
                     this->chunks.push_back({0, static_cast<int>(this->pattern.size())});
-                    this->checkAndMergeIfFound("{TYPE}",   -2);
-                    this->checkAndMergeIfFound("{DATE}",   -1);
-                    this->checkAndMergeIfFound("{THREAD}", -3);
-                    this->checkAndMergeIfFound("{TIME}",   -4);
+                    SPLIT_AND_MERGE(typePos,   TAG_TYPE, TAG_TYPE_ID);
+                    SPLIT_AND_MERGE(datePos,   TAG_DATE, TAG_DATE_ID);
+                    SPLIT_AND_MERGE(threadPos, TAG_THREAD, TAG_THREAD_ID);
                 }
+#               undef SPLIT_AND_MERGE
         };
         template<typename T>
         class __Static_declarer
         {
             protected:
-                static bool                                   ENABLE_LOG;
-                static bool                                   ENABLE_COLOR;
-                static bool                                   ENABLE_SPACING;
-                static bool                                   ENABLE_DEBUG;
-                static bool                                   ENABLE_INFO;
-                static bool                                   ENABLE_ERROR;
-                static bool                                   ENABLE_WARNING;
-                static bool                                   ENABLE_FATAL;
-                static bool                                   ENABLE_TRACE;
-                static bool                                   ENABLE_HEADER;
-                static std::ostream*                          OUT;
-                static bool                                   ENABLE_ALPHA_BOOL;
+                static bool          ENABLE_LOG;
+                static bool          ENABLE_COLOR;
+                static bool          ENABLE_SPACING;
+                static bool          ENABLE_DEBUG;
+                static bool          ENABLE_INFO;
+                static bool          ENABLE_ERROR;
+                static bool          ENABLE_WARNING;
+                static bool          ENABLE_FATAL;
+                static std::ostream* OUT;
+                static bool          ENABLE_ALPHA_BOOL;
                 static MTL_LOG_NAMESPACE::__details::__Header FORMAT;
                 
+#               ifdef _REENTRANT
+                static std::map<std::thread::id, std::string> THREAD_NAME;
+#               endif
             private:
-#               ifdef MTL_LOG_WITH_THREADS
-                static std::mutex MUTEX;
+#               ifdef _REENTRANT
+                static std::mutex    MUTEX;
 #               endif
                 static constexpr const char *const C_YELLOW = "\033[1;33m";
                 static constexpr const char *const C_RED    = "\033[1;31m";
                 static constexpr const char *const C_GREEN  = "\033[1;32m";
                 static constexpr const char *const C_BLUE   = "\033[1;36m";
                 static constexpr const char *const C_BLANK  = "\033[0m";
-                friend class MTL_LOG_NAMESPACE::__details::_Logger;
+                friend class _Logger;
                 __DETAILS_FRIENDSHIPS
                 __Static_declarer(void) = delete;
         };
@@ -214,32 +218,23 @@ namespace MTL_LOG_NAMESPACE
         STATIC_DECLARATION(bool,          ENABLE_ERROR,      true)
         STATIC_DECLARATION(bool,          ENABLE_WARNING,    true)
         STATIC_DECLARATION(bool,          ENABLE_FATAL,      true)
-        STATIC_DECLARATION(bool,          ENABLE_TRACE,      true)
-        STATIC_DECLARATION(bool,          ENABLE_HEADER,     true)
         STATIC_DECLARATION(std::ostream*, OUT,               &std::cout)
         STATIC_DECLARATION(bool,          ENABLE_ALPHA_BOOL, true)
-#       ifdef MTL_LOG_WITH_THREADS
+#       ifdef _REENTRANT
         template<typename T> std::mutex __Static_declarer<T>::MUTEX;
+        template<typename T> std::map<std::thread::id, std::string> __Static_declarer<T>::THREAD_NAME = {};
 #       endif
-        STATIC_DECLARATION(MTL_LOG_NAMESPACE::__details::__Header, FORMAT, std::string("[{TYPE} {DATE} {TIME}] : "))
+        STATIC_DECLARATION(MTL_LOG_NAMESPACE::__details::__Header, FORMAT, std::string("[{TYPE} {DATE}] :"))
 #       undef STATIC_DECLARATION
     }
-#   ifndef MTL_LOG_WITH_THREAD
-#       define MTL_LOG_LOCK \
-            do{}while(false)
-#   else
-#       define MTL_LOG_LOCK \
-            std::unique_lock<std::mutex> lck(MTL_LOG_NAMESPACE::Options::MUTEX)
-#   endif
+    
 #   define MTL_LOG_GET_SET(type, name, option) \
-        static void enable##name(type value) noexcept\
+        static inline void enable##name(type value) noexcept\
         {\
-            MTL_LOG_LOCK;\
             MTL_LOG_NAMESPACE::Options::option = value;\
         }\
-        static type is##name##Enabled(void) noexcept\
+        static inline type is##name##Enabled(void) noexcept\
         {\
-            MTL_LOG_LOCK;\
             return MTL_LOG_NAMESPACE::Options::option;\
         }
     class DECLSPEC Options final : public MTL_LOG_NAMESPACE::__details::__Static_declarer<MTL_LOG_NAMESPACE::Options>
@@ -255,28 +250,25 @@ namespace MTL_LOG_NAMESPACE
             MTL_LOG_GET_SET(bool, Error,     ENABLE_ERROR)
             MTL_LOG_GET_SET(bool, Fatal,     ENABLE_FATAL)
             MTL_LOG_GET_SET(bool, Info,      ENABLE_INFO)
-            MTL_LOG_GET_SET(bool, Header,    ENABLE_HEADER)
-            MTL_LOG_GET_SET(bool, Trace,     ENABLE_TRACE)
             static void setOutputStream(std::ostream* out)
             {
-                MTL_LOG_LOCK;
                 MTL_LOG_NAMESPACE::Options::OUT = out;
-            }
-            static std::ostream* getOutputStream(void)
-            {
-                MTL_LOG_LOCK;
-                return MTL_LOG_NAMESPACE::Options::OUT;
             }
             static void setFormat(const std::string& format)
             {
-                MTL_LOG_LOCK;
                 MTL_LOG_NAMESPACE::Options::FORMAT = format;
             }
-            static std::string getFormat(void)
+#           ifdef _REENTRANT
+            static void addThreadName(const std::thread::id& id, const std::string& name)
             {
-                MTL_LOG_LOCK;
-                return MTL_LOG_NAMESPACE::Options::FORMAT;
+                MTL_LOG_NAMESPACE::Options::THREAD_NAME.insert(std::make_pair(id, name));
             }
+            static void delThreadName(const std::thread::id& id)
+            {
+                MTL_LOG_NAMESPACE::Options::THREAD_NAME.erase(id);
+            }
+#           endif
+        
     };
     
 #   undef MTL_LOG_GET_SET
@@ -287,25 +279,23 @@ namespace MTL_LOG_NAMESPACE
             private:
                 _Logger(void) = delete;
                 __DETAILS_FRIENDSHIPS
+                
                 static void _print_(void)
                 {
                     *MTL_LOG_NAMESPACE::Options::OUT << std::endl;
                 }
-                template<typename Actual>
-                static void _print_(const Actual& a)
-                {
-                    *MTL_LOG_NAMESPACE::Options::OUT << a << std::endl;
-                }
+                
                 template<typename Actual, typename... Args>
                 static void _print_(const Actual& a, const Args&... args)
                 {
-                    *MTL_LOG_NAMESPACE::Options::OUT << a;
                     if (MTL_LOG_NAMESPACE::Options::ENABLE_SPACING)
                     {
                         *MTL_LOG_NAMESPACE::Options::OUT << ' ';
                     }
+                    *MTL_LOG_NAMESPACE::Options::OUT << a;
                     MTL_LOG_NAMESPACE::__details::_Logger::_print_(args...);
                 }
+                
                 static void assertValidity(void)
                 {
                     if (MTL_LOG_NAMESPACE::Options::OUT == nullptr)
@@ -317,21 +307,34 @@ namespace MTL_LOG_NAMESPACE
                         throw std::ios_base::failure("OUT must be a \"good()\" std::ostream* !");
                     }
                 }
+                
                 template<typename... Args>
                 static void _start_print(const char *const tag, const char *const color, const Args&... args)
                 {
-                    MTL_LOG_LOCK;
+#                   ifdef _REENTRANT
+                    MTL_LOG_NAMESPACE::Options::MUTEX.lock();
+#                   endif
                     MTL_LOG_NAMESPACE::__details::_Logger::assertValidity();
                     *MTL_LOG_NAMESPACE::Options::OUT << ((MTL_LOG_NAMESPACE::Options::isAlphaBoolEnabled()) ? std::boolalpha
                                                                                                             : std::noboolalpha);
-                    if (MTL_LOG_NAMESPACE::Options::isHeaderEnabled())
+                    MTL_LOG_NAMESPACE::Options::FORMAT.display(*MTL_LOG_NAMESPACE::Options::OUT,
+                                                               tag, color,
+                                                               MTL_LOG_NAMESPACE::Options::C_BLANK,
+                                                               MTL_LOG_NAMESPACE::Options::isColorEnabled(),
+#                                                              ifdef _REENTRANT
+                                                               &MTL_LOG_NAMESPACE::Options::THREAD_NAME
+#                                                              else
+                                                               nullptr
+#                                                              endif
+                                                               );
+                    if (!MTL_LOG_NAMESPACE::Options::ENABLE_SPACING)
                     {
-                        MTL_LOG_NAMESPACE::Options::FORMAT.display(*MTL_LOG_NAMESPACE::Options::OUT,
-                                                                   tag, color,
-                                                                   MTL_LOG_NAMESPACE::Options::C_BLANK,
-                                                                   MTL_LOG_NAMESPACE::Options::isColorEnabled());
+                        *MTL_LOG_NAMESPACE::Options::OUT << ' ';
                     }
                     MTL_LOG_NAMESPACE::__details::_Logger::_print_(args...);
+#                   ifdef _REENTRANT
+                    MTL_LOG_NAMESPACE::Options::MUTEX.unlock();
+#                   endif
                 }
             
         };
@@ -353,15 +356,13 @@ namespace MTL_LOG_NAMESPACE
     MTL_LOG_METHOD(error,   "ERROR  ", C_RED,    Error)
     MTL_LOG_METHOD(fatal,   "FATAL  ", C_RED,    Fatal)
     MTL_LOG_METHOD(debug,   "DEBUG  ", C_BLUE,   Debug)
-    MTL_LOG_METHOD(trace,   "TRACE  ", C_BLUE,   Trace)
 #   undef MTL_LOG_METHOD
-#   undef MTL_LOG_LOCK
     
-#   define MTL_LOG_DUMP_LINE(file, text) file << text << std::endl;
-#   define MTL_LOG_READ_BOOL(varname) \
+#   define DUMP_LINE(file, text) file << text << std::endl;
+#   define READ_BOOL(varname) \
         config >> foo >> equal >> value;\
         MTL_LOG_NAMESPACE::Options::enable##varname(value);
-    inline DECLSPEC bool loadConfiguration(const std::string& fname)
+    inline DECLSPEC void loadConfiguration(const std::string& fname)
     {
         std::ifstream config(fname);
         if (config.good())
@@ -369,49 +370,42 @@ namespace MTL_LOG_NAMESPACE
             std::string foo;
             char        equal;
             bool        value;
-            MTL_LOG_READ_BOOL(Log);
-            MTL_LOG_READ_BOOL(Color);
-            MTL_LOG_READ_BOOL(Spacing);
-            MTL_LOG_READ_BOOL(AlphaBool);
-            MTL_LOG_READ_BOOL(Info);
-            MTL_LOG_READ_BOOL(Warning);
-            MTL_LOG_READ_BOOL(Error);
-            MTL_LOG_READ_BOOL(Fatal);
-            MTL_LOG_READ_BOOL(Debug);
-            MTL_LOG_READ_BOOL(Trace);
-            MTL_LOG_READ_BOOL(Header);
+            READ_BOOL(Log);
+            READ_BOOL(Color);
+            READ_BOOL(Spacing);
+            READ_BOOL(AlphaBool);
+            READ_BOOL(Info);
+            READ_BOOL(Warning);
+            READ_BOOL(Error);
+            READ_BOOL(Fatal);
+            READ_BOOL(Debug);
             config >> foo >> equal;
             std::getline(config, foo);
             MTL_LOG_NAMESPACE::Options::setFormat(foo);
             config.close();
-            return true;
         }
         else
         {
             std::ofstream dump(fname);
             if (dump.good())
             {
-                MTL_LOG_DUMP_LINE(dump, "ENABLE_LOG:bool        = 1");
-                MTL_LOG_DUMP_LINE(dump, "ENABLE_COLOR:bool      = 0");
-                MTL_LOG_DUMP_LINE(dump, "ENABLE_SPACING:bool    = 1");
-                MTL_LOG_DUMP_LINE(dump, "ENABLE_ALPHA_BOOL:bool = 1");
-                MTL_LOG_DUMP_LINE(dump, "ENABLE_INFO:bool       = 1");
-                MTL_LOG_DUMP_LINE(dump, "ENABLE_WARNING:bool    = 1");
-                MTL_LOG_DUMP_LINE(dump, "ENABLE_ERROR:bool      = 1");
-                MTL_LOG_DUMP_LINE(dump, "ENABLE_FATAL:bool      = 1");
-                MTL_LOG_DUMP_LINE(dump, "ENABLE_DEBUG:bool      = 1");
-                MTL_LOG_DUMP_LINE(dump, "ENABLE_TRACE:bool      = 1");
-                MTL_LOG_DUMP_LINE(dump, "ENABLE_HEADER:bool     = 1");
-                MTL_LOG_DUMP_LINE(dump, "HEADER_FORMAT:string   =[{TYPE} {DATE}] : ");
+                DUMP_LINE(dump, "ENABLE_LOG:bool        = 1");
+                DUMP_LINE(dump, "ENABLE_COLOR:bool      = 0");
+                DUMP_LINE(dump, "ENABLE_SPACING:bool    = 1");
+                DUMP_LINE(dump, "ENABLE_ALPHA_BOOL:bool = 1");
+                DUMP_LINE(dump, "ENABLE_INFO:bool       = 1");
+                DUMP_LINE(dump, "ENABLE_WARNING:bool    = 1");
+                DUMP_LINE(dump, "ENABLE_ERROR:bool      = 1");
+                DUMP_LINE(dump, "ENABLE_FATAL:bool      = 1");
+                DUMP_LINE(dump, "ENABLE_DEBUG:bool      = 1");
+                DUMP_LINE(dump, "HEADER_FORMAT:string   =[{TYPE} {DATE}] : ");
                 dump.close();
             }
-            return false;
         }
     }
-#   undef MTL_LOG_DUMP_LINE
-#   undef MTL_LOG_READ_BOOL
+#   undef DUMP_LINE
+#   undef READ_BOOL
 #   undef __DETAILS_FRIENDSHIPS
 #   undef MTL_LOG_FRIEND
-#   undef MTL_LOG_WITH_THREADS
 }
 #endif

--- a/logs.hpp
+++ b/logs.hpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <ctime>
 #include <fstream>
+#include <sstream>
 #include <iostream>
 #include <string>
 #include <utility>
@@ -12,6 +13,9 @@
 
 // if -pthread or -fopenmp provided only
 #ifdef _REENTRANT
+#   define MTL_LOG_WITH_THREADS
+#endif
+#ifdef MTL_LOG_WITH_THREADS
 #   include <thread>
 #   include <mutex>
 #endif
@@ -34,6 +38,7 @@
 #   endif
 #endif
 
+#define MTL_LOG_VARIABLE(varname) #varname " =", varname
 
 namespace MTL_LOG_NAMESPACE
 {
@@ -44,7 +49,8 @@ namespace MTL_LOG_NAMESPACE
     MTL_LOG_DECLARE(error)
     MTL_LOG_DECLARE(fatal)
     MTL_LOG_DECLARE(debug)
-    inline DECLSPEC void loadConfiguration(const std::string& fname);
+    MTL_LOG_DECLARE(trace)
+    inline DECLSPEC bool loadConfiguration(const std::string& fname);
 #   undef MTL_LOG_DECLARE
     
     namespace __details
@@ -57,7 +63,8 @@ namespace MTL_LOG_NAMESPACE
             MTL_LOG_FRIEND(warning) \
             MTL_LOG_FRIEND(error) \
             MTL_LOG_FRIEND(fatal) \
-            MTL_LOG_FRIEND(debug)
+            MTL_LOG_FRIEND(debug) \
+            MTL_LOG_FRIEND(trace)
         
         class __Header final
         {
@@ -74,29 +81,39 @@ namespace MTL_LOG_NAMESPACE
                     return *this;
                 }
                 ~__Header(void) = default;
+                operator std::string(void)
+                {
+                    return this->pattern;
+                }
                 void display(std::ostream& out, const std::string& type, const char *const color,
                              const char *const nocolor, bool colorEnabled, const void* threads_names)
                 {
 #                   ifdef _REENTRANT
                     const std::map<std::thread::id, std::string>* thread = reinterpret_cast<const std::map<std::thread::id, std::string>*>(threads_names);
 #                   endif
-                    for(const std::pair<int, int>& p : this->chunks)
+                    for(const auto& p : this->chunks)
                     {
                         switch(p.first)
                         {
-                            case MTL_LOG_NAMESPACE::__details::__Header::TAG_DATE_ID:
+                            case -1:
                             {
                                 time_t  tt  = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
                                 std::tm ltm = *localtime(&tt);
                                 this->printTwoDigits(out, ltm.tm_mon+1) << '/';
                                 this->printTwoDigits(out, ltm.tm_mday)  << '/';
-                                out << ltm.tm_year + 1900 << ' ';
+                                out << ltm.tm_year + 1900;
+                                break;
+                            }
+                            case -4:
+                            {
+                                time_t  tt  = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+                                std::tm ltm = *localtime(&tt);
                                 this->printTwoDigits(out, ltm.tm_hour) << ':';
                                 this->printTwoDigits(out, ltm.tm_min) << ':';
                                 this->printTwoDigits(out, ltm.tm_sec);
                                 break;
                             }
-                            case MTL_LOG_NAMESPACE::__details::__Header::TAG_THREAD_ID:
+                            case -3:
 #                               ifdef _REENTRANT
                                 try
                                 {
@@ -108,7 +125,7 @@ namespace MTL_LOG_NAMESPACE
                                 }
 #                               endif
                                 break;
-                            case MTL_LOG_NAMESPACE::__details::__Header::TAG_TYPE_ID:
+                            case -2:
                                 if (colorEnabled)
                                 {
                                     out << color;
@@ -128,23 +145,15 @@ namespace MTL_LOG_NAMESPACE
                     }
                 }
             private:
-                static constexpr const int         TAG_DATE_ID    = -1;
-                static constexpr const int         TAG_TYPE_ID    = -2;
-                static constexpr const int         TAG_THREAD_ID  = -3;
-                static constexpr const char *const TAG_TYPE       = "{TYPE}";
-                static constexpr const char *const TAG_THREAD     = "{THREAD}";
-                static constexpr const char *const TAG_DATE       = "{DATE}";
                 std::string                      pattern;
                 std::vector<std::pair<int, int>> chunks;
                 inline std::ostream& printTwoDigits(std::ostream& out, int value)
                 {
-                    out << ((value < 10) ? "0" : "") << value;
-                    return out;
+                    return out << ((value < 10) ? "0" : "") << value;
                 }
                 void splitAndMerge(int begin, int end, int id)
                 {
-                    auto it=this->chunks.begin();
-                    for(;it!=this->chunks.end();++it)
+                    for(auto it=this->chunks.begin();it!=this->chunks.end();++it)
                     {
                         if (it->second > begin)
                         {
@@ -157,54 +166,55 @@ namespace MTL_LOG_NAMESPACE
                         }
                     }
                 }
-#               define SPLIT_AND_MERGE(var, tag, id) \
-                    if (var != std::string::npos)\
-                    {\
-                        this->splitAndMerge(static_cast<int>(var),\
-                            static_cast<int>(std::string(MTL_LOG_NAMESPACE::__details::__Header::tag).length()), id);\
+                void checkAndMergeIfFound(const std::string& tag, int id)
+                {
+                    std::size_t pos = this->pattern.find(tag);
+                    if (pos != std::string::npos)
+                    {
+                        this->splitAndMerge(static_cast<int>(pos), static_cast<int>(tag.length()), id);
                     }
+                }
                 void build(void)
                 {
                     this->chunks.clear();
-                    std::size_t typePos    = this->pattern.find(MTL_LOG_NAMESPACE::__details::__Header::TAG_TYPE);
-                    std::size_t threadPos  = this->pattern.find(MTL_LOG_NAMESPACE::__details::__Header::TAG_THREAD);
-                    std::size_t datePos    = this->pattern.find(MTL_LOG_NAMESPACE::__details::__Header::TAG_DATE);
                     this->chunks.push_back({0, static_cast<int>(this->pattern.size())});
-                    SPLIT_AND_MERGE(typePos,   TAG_TYPE, TAG_TYPE_ID);
-                    SPLIT_AND_MERGE(datePos,   TAG_DATE, TAG_DATE_ID);
-                    SPLIT_AND_MERGE(threadPos, TAG_THREAD, TAG_THREAD_ID);
+                    this->checkAndMergeIfFound("{TYPE}",   -2);
+                    this->checkAndMergeIfFound("{DATE}",   -1);
+                    this->checkAndMergeIfFound("{THREAD}", -3);
+                    this->checkAndMergeIfFound("{TIME}",   -4);
                 }
-#               undef SPLIT_AND_MERGE
         };
         template<typename T>
         class __Static_declarer
         {
             protected:
-                static bool          ENABLE_LOG;
-                static bool          ENABLE_COLOR;
-                static bool          ENABLE_SPACING;
-                static bool          ENABLE_DEBUG;
-                static bool          ENABLE_INFO;
-                static bool          ENABLE_ERROR;
-                static bool          ENABLE_WARNING;
-                static bool          ENABLE_FATAL;
-                static std::ostream* OUT;
-                static bool          ENABLE_ALPHA_BOOL;
+                static bool                                   ENABLE_LOG;
+                static bool                                   ENABLE_COLOR;
+                static bool                                   ENABLE_SPACING;
+                static bool                                   ENABLE_DEBUG;
+                static bool                                   ENABLE_INFO;
+                static bool                                   ENABLE_ERROR;
+                static bool                                   ENABLE_WARNING;
+                static bool                                   ENABLE_FATAL;
+                static bool                                   ENABLE_TRACE;
+                static bool                                   ENABLE_HEADER;
+                static std::ostream*                          OUT;
+                static bool                                   ENABLE_ALPHA_BOOL;
                 static MTL_LOG_NAMESPACE::__details::__Header FORMAT;
                 
 #               ifdef _REENTRANT
                 static std::map<std::thread::id, std::string> THREAD_NAME;
 #               endif
             private:
-#               ifdef _REENTRANT
-                static std::mutex    MUTEX;
+#               ifdef MTL_LOG_WITH_THREADS
+                static std::mutex MUTEX;
 #               endif
                 static constexpr const char *const C_YELLOW = "\033[1;33m";
                 static constexpr const char *const C_RED    = "\033[1;31m";
                 static constexpr const char *const C_GREEN  = "\033[1;32m";
                 static constexpr const char *const C_BLUE   = "\033[1;36m";
                 static constexpr const char *const C_BLANK  = "\033[0m";
-                friend class _Logger;
+                friend class MTL_LOG_NAMESPACE::__details::_Logger;
                 __DETAILS_FRIENDSHIPS
                 __Static_declarer(void) = delete;
         };
@@ -218,23 +228,33 @@ namespace MTL_LOG_NAMESPACE
         STATIC_DECLARATION(bool,          ENABLE_ERROR,      true)
         STATIC_DECLARATION(bool,          ENABLE_WARNING,    true)
         STATIC_DECLARATION(bool,          ENABLE_FATAL,      true)
+        STATIC_DECLARATION(bool,          ENABLE_TRACE,      true)
+        STATIC_DECLARATION(bool,          ENABLE_HEADER,     true)
         STATIC_DECLARATION(std::ostream*, OUT,               &std::cout)
         STATIC_DECLARATION(bool,          ENABLE_ALPHA_BOOL, true)
-#       ifdef _REENTRANT
+#       ifdef MTL_LOG_WITH_THREADS
         template<typename T> std::mutex __Static_declarer<T>::MUTEX;
         template<typename T> std::map<std::thread::id, std::string> __Static_declarer<T>::THREAD_NAME = {};
 #       endif
-        STATIC_DECLARATION(MTL_LOG_NAMESPACE::__details::__Header, FORMAT, std::string("[{TYPE} {DATE}] :"))
+        STATIC_DECLARATION(MTL_LOG_NAMESPACE::__details::__Header, FORMAT, std::string("[{TYPE} {DATE} {TIME}] : "))
 #       undef STATIC_DECLARATION
     }
-    
+#   ifndef MTL_LOG_WITH_THREAD
+#       define MTL_LOG_LOCK \
+            do{}while(false)
+#   else
+#       define MTL_LOG_LOCK \
+            std::unique_lock<std::mutex> lck(MTL_LOG_NAMESPACE::Options::MUTEX)
+#   endif
 #   define MTL_LOG_GET_SET(type, name, option) \
-        static inline void enable##name(type value) noexcept\
+        static void enable##name(type value) noexcept\
         {\
+            MTL_LOG_LOCK;\
             MTL_LOG_NAMESPACE::Options::option = value;\
         }\
-        static inline type is##name##Enabled(void) noexcept\
+        static type is##name##Enabled(void) noexcept\
         {\
+            MTL_LOG_LOCK;\
             return MTL_LOG_NAMESPACE::Options::option;\
         }
     class DECLSPEC Options final : public MTL_LOG_NAMESPACE::__details::__Static_declarer<MTL_LOG_NAMESPACE::Options>
@@ -250,13 +270,27 @@ namespace MTL_LOG_NAMESPACE
             MTL_LOG_GET_SET(bool, Error,     ENABLE_ERROR)
             MTL_LOG_GET_SET(bool, Fatal,     ENABLE_FATAL)
             MTL_LOG_GET_SET(bool, Info,      ENABLE_INFO)
+            MTL_LOG_GET_SET(bool, Header,    ENABLE_HEADER)
+            MTL_LOG_GET_SET(bool, Trace,     ENABLE_TRACE)
             static void setOutputStream(std::ostream* out)
             {
+                MTL_LOG_LOCK;
                 MTL_LOG_NAMESPACE::Options::OUT = out;
+            }
+            static std::ostream* getOutputStream(void)
+            {
+                MTL_LOG_LOCK;
+                return MTL_LOG_NAMESPACE::Options::OUT;
             }
             static void setFormat(const std::string& format)
             {
+                MTL_LOG_LOCK;
                 MTL_LOG_NAMESPACE::Options::FORMAT = format;
+            }
+            static std::string getFormat(void)
+            {
+                MTL_LOG_LOCK;
+                return MTL_LOG_NAMESPACE::Options::FORMAT;
             }
 #           ifdef _REENTRANT
             static void addThreadName(const std::thread::id& id, const std::string& name)
@@ -268,7 +302,6 @@ namespace MTL_LOG_NAMESPACE
                 MTL_LOG_NAMESPACE::Options::THREAD_NAME.erase(id);
             }
 #           endif
-        
     };
     
 #   undef MTL_LOG_GET_SET
@@ -279,23 +312,25 @@ namespace MTL_LOG_NAMESPACE
             private:
                 _Logger(void) = delete;
                 __DETAILS_FRIENDSHIPS
-                
                 static void _print_(void)
                 {
                     *MTL_LOG_NAMESPACE::Options::OUT << std::endl;
                 }
-                
+                template<typename Actual>
+                static void _print_(const Actual& a)
+                {
+                    *MTL_LOG_NAMESPACE::Options::OUT << a << std::endl;
+                }
                 template<typename Actual, typename... Args>
                 static void _print_(const Actual& a, const Args&... args)
                 {
+                    *MTL_LOG_NAMESPACE::Options::OUT << a;
                     if (MTL_LOG_NAMESPACE::Options::ENABLE_SPACING)
                     {
                         *MTL_LOG_NAMESPACE::Options::OUT << ' ';
                     }
-                    *MTL_LOG_NAMESPACE::Options::OUT << a;
                     MTL_LOG_NAMESPACE::__details::_Logger::_print_(args...);
                 }
-                
                 static void assertValidity(void)
                 {
                     if (MTL_LOG_NAMESPACE::Options::OUT == nullptr)
@@ -307,34 +342,27 @@ namespace MTL_LOG_NAMESPACE
                         throw std::ios_base::failure("OUT must be a \"good()\" std::ostream* !");
                     }
                 }
-                
                 template<typename... Args>
                 static void _start_print(const char *const tag, const char *const color, const Args&... args)
                 {
-#                   ifdef _REENTRANT
-                    MTL_LOG_NAMESPACE::Options::MUTEX.lock();
-#                   endif
+                    MTL_LOG_LOCK;
                     MTL_LOG_NAMESPACE::__details::_Logger::assertValidity();
                     *MTL_LOG_NAMESPACE::Options::OUT << ((MTL_LOG_NAMESPACE::Options::isAlphaBoolEnabled()) ? std::boolalpha
                                                                                                             : std::noboolalpha);
-                    MTL_LOG_NAMESPACE::Options::FORMAT.display(*MTL_LOG_NAMESPACE::Options::OUT,
-                                                               tag, color,
-                                                               MTL_LOG_NAMESPACE::Options::C_BLANK,
-                                                               MTL_LOG_NAMESPACE::Options::isColorEnabled(),
-#                                                              ifdef _REENTRANT
-                                                               &MTL_LOG_NAMESPACE::Options::THREAD_NAME
-#                                                              else
-                                                               nullptr
-#                                                              endif
-                                                               );
-                    if (!MTL_LOG_NAMESPACE::Options::ENABLE_SPACING)
+                    if (MTL_LOG_NAMESPACE::Options::isHeaderEnabled())
                     {
-                        *MTL_LOG_NAMESPACE::Options::OUT << ' ';
+                        MTL_LOG_NAMESPACE::Options::FORMAT.display(*MTL_LOG_NAMESPACE::Options::OUT,
+                                                                   tag, color,
+                                                                   MTL_LOG_NAMESPACE::Options::C_BLANK,
+                                                                   MTL_LOG_NAMESPACE::Options::isColorEnabled(),
+#                                                                  ifdef _REENTRANT
+                                                                   &MTL_LOG_NAMESPACE::Options::THREAD_NAME
+#                                                                  else
+                                                                   nullptr
+#                                                                  endif
+                                                                   );
                     }
                     MTL_LOG_NAMESPACE::__details::_Logger::_print_(args...);
-#                   ifdef _REENTRANT
-                    MTL_LOG_NAMESPACE::Options::MUTEX.unlock();
-#                   endif
                 }
             
         };
@@ -356,13 +384,15 @@ namespace MTL_LOG_NAMESPACE
     MTL_LOG_METHOD(error,   "ERROR  ", C_RED,    Error)
     MTL_LOG_METHOD(fatal,   "FATAL  ", C_RED,    Fatal)
     MTL_LOG_METHOD(debug,   "DEBUG  ", C_BLUE,   Debug)
+    MTL_LOG_METHOD(trace,   "TRACE  ", C_BLUE,   Trace)
 #   undef MTL_LOG_METHOD
+#   undef MTL_LOG_LOCK
     
-#   define DUMP_LINE(file, text) file << text << std::endl;
-#   define READ_BOOL(varname) \
+#   define MTL_LOG_DUMP_LINE(file, text) file << text << std::endl;
+#   define MTL_LOG_READ_BOOL(varname) \
         config >> foo >> equal >> value;\
         MTL_LOG_NAMESPACE::Options::enable##varname(value);
-    inline DECLSPEC void loadConfiguration(const std::string& fname)
+    inline DECLSPEC bool loadConfiguration(const std::string& fname)
     {
         std::ifstream config(fname);
         if (config.good())
@@ -370,42 +400,49 @@ namespace MTL_LOG_NAMESPACE
             std::string foo;
             char        equal;
             bool        value;
-            READ_BOOL(Log);
-            READ_BOOL(Color);
-            READ_BOOL(Spacing);
-            READ_BOOL(AlphaBool);
-            READ_BOOL(Info);
-            READ_BOOL(Warning);
-            READ_BOOL(Error);
-            READ_BOOL(Fatal);
-            READ_BOOL(Debug);
+            MTL_LOG_READ_BOOL(Log);
+            MTL_LOG_READ_BOOL(Color);
+            MTL_LOG_READ_BOOL(Spacing);
+            MTL_LOG_READ_BOOL(AlphaBool);
+            MTL_LOG_READ_BOOL(Info);
+            MTL_LOG_READ_BOOL(Warning);
+            MTL_LOG_READ_BOOL(Error);
+            MTL_LOG_READ_BOOL(Fatal);
+            MTL_LOG_READ_BOOL(Debug);
+            MTL_LOG_READ_BOOL(Trace);
+            MTL_LOG_READ_BOOL(Header);
             config >> foo >> equal;
             std::getline(config, foo);
             MTL_LOG_NAMESPACE::Options::setFormat(foo);
             config.close();
+            return true;
         }
         else
         {
             std::ofstream dump(fname);
             if (dump.good())
             {
-                DUMP_LINE(dump, "ENABLE_LOG:bool        = 1");
-                DUMP_LINE(dump, "ENABLE_COLOR:bool      = 0");
-                DUMP_LINE(dump, "ENABLE_SPACING:bool    = 1");
-                DUMP_LINE(dump, "ENABLE_ALPHA_BOOL:bool = 1");
-                DUMP_LINE(dump, "ENABLE_INFO:bool       = 1");
-                DUMP_LINE(dump, "ENABLE_WARNING:bool    = 1");
-                DUMP_LINE(dump, "ENABLE_ERROR:bool      = 1");
-                DUMP_LINE(dump, "ENABLE_FATAL:bool      = 1");
-                DUMP_LINE(dump, "ENABLE_DEBUG:bool      = 1");
-                DUMP_LINE(dump, "HEADER_FORMAT:string   =[{TYPE} {DATE}] : ");
+                MTL_LOG_DUMP_LINE(dump, "ENABLE_LOG:bool        = 1");
+                MTL_LOG_DUMP_LINE(dump, "ENABLE_COLOR:bool      = 0");
+                MTL_LOG_DUMP_LINE(dump, "ENABLE_SPACING:bool    = 1");
+                MTL_LOG_DUMP_LINE(dump, "ENABLE_ALPHA_BOOL:bool = 1");
+                MTL_LOG_DUMP_LINE(dump, "ENABLE_INFO:bool       = 1");
+                MTL_LOG_DUMP_LINE(dump, "ENABLE_WARNING:bool    = 1");
+                MTL_LOG_DUMP_LINE(dump, "ENABLE_ERROR:bool      = 1");
+                MTL_LOG_DUMP_LINE(dump, "ENABLE_FATAL:bool      = 1");
+                MTL_LOG_DUMP_LINE(dump, "ENABLE_DEBUG:bool      = 1");
+                MTL_LOG_DUMP_LINE(dump, "ENABLE_TRACE:bool      = 1");
+                MTL_LOG_DUMP_LINE(dump, "ENABLE_HEADER:bool     = 1");
+                MTL_LOG_DUMP_LINE(dump, "HEADER_FORMAT:string   =[{TYPE} {DATE}] : ");
                 dump.close();
             }
+            return false;
         }
     }
-#   undef DUMP_LINE
-#   undef READ_BOOL
+#   undef MTL_LOG_DUMP_LINE
+#   undef MTL_LOG_READ_BOOL
 #   undef __DETAILS_FRIENDSHIPS
 #   undef MTL_LOG_FRIEND
+#   undef MTL_LOG_WITH_THREADS
 }
 #endif

--- a/logs.hpp
+++ b/logs.hpp
@@ -88,7 +88,7 @@ namespace MTL_LOG_NAMESPACE
                 void display(std::ostream& out, const std::string& type, const char *const color,
                              const char *const nocolor, bool colorEnabled, const void* threads_names)
                 {
-#                   ifdef _REENTRANT
+#                   ifdef MTL_LOG_WITH_THREADS
                     const std::map<std::thread::id, std::string>* thread = reinterpret_cast<const std::map<std::thread::id, std::string>*>(threads_names);
 #                   endif
                     for(const auto& p : this->chunks)
@@ -114,7 +114,7 @@ namespace MTL_LOG_NAMESPACE
                                 break;
                             }
                             case -3:
-#                               ifdef _REENTRANT
+#                               ifdef MTL_LOG_WITH_THREADS
                                 try
                                 {
                                     out << (*thread).at(std::this_thread::get_id());
@@ -202,7 +202,7 @@ namespace MTL_LOG_NAMESPACE
                 static bool                                   ENABLE_ALPHA_BOOL;
                 static MTL_LOG_NAMESPACE::__details::__Header FORMAT;
                 
-#               ifdef _REENTRANT
+#               ifdef MTL_LOG_WITH_THREADS
                 static std::map<std::thread::id, std::string> THREAD_NAME;
 #               endif
             private:
@@ -292,7 +292,7 @@ namespace MTL_LOG_NAMESPACE
                 MTL_LOG_LOCK;
                 return MTL_LOG_NAMESPACE::Options::FORMAT;
             }
-#           ifdef _REENTRANT
+#           ifdef MTL_LOG_WITH_THREADS
             static void bindThreadName(const std::thread::id& id, const std::string& name)
             {
                 MTL_LOG_NAMESPACE::Options::THREAD_NAME.insert(std::make_pair(id, name));
@@ -355,7 +355,7 @@ namespace MTL_LOG_NAMESPACE
                                                                    tag, color,
                                                                    MTL_LOG_NAMESPACE::Options::C_BLANK,
                                                                    MTL_LOG_NAMESPACE::Options::isColorEnabled(),
-#                                                                  ifdef _REENTRANT
+#                                                                  ifdef MTL_LOG_WITH_THREADS
                                                                    &MTL_LOG_NAMESPACE::Options::THREAD_NAME
 #                                                                  else
                                                                    nullptr

--- a/logs.hpp
+++ b/logs.hpp
@@ -292,16 +292,21 @@ namespace MTL_LOG_NAMESPACE
                 MTL_LOG_LOCK;
                 return MTL_LOG_NAMESPACE::Options::FORMAT;
             }
-#           ifdef MTL_LOG_WITH_THREADS
-            static void bindThreadName(const std::thread::id& id, const std::string& name)
+
+            static void bindThreadName(const std::string& name)
             {
-                MTL_LOG_NAMESPACE::Options::THREAD_NAME.insert(std::make_pair(id, name));
+#               ifdef MTL_LOG_WITH_THREADS
+                MTL_LOG_LOCK;
+                MTL_LOG_NAMESPACE::Options::THREAD_NAME.insert(std::make_pair(std::this_thread::get_id(), name));
+#               endif
             }
-            static void unbidThreadName(const std::thread::id& id)
+            static void unbidThreadName()
             {
-                MTL_LOG_NAMESPACE::Options::THREAD_NAME.erase(id);
+#               ifdef MTL_LOG_WITH_THREADS
+                MTL_LOG_LOCK;
+                MTL_LOG_NAMESPACE::Options::THREAD_NAME.erase(std::this_thread::get_id());
+#               endif
             }
-#           endif
     };
     
 #   undef MTL_LOG_GET_SET


### PR DESCRIPTION
I've added a feature that binds a thread id to a string.
This allows a user to set a name to several threads.
It gives thins kind of output for this code :
```
#include "logs.hpp"
#include <thread>

void printNameTest()
{
	mlog::Options::setFormat("[{TYPE} {DATE} {TIME} {THREAD}] ");
	mlog::info("Before binding the TEST value");
	mlog::Options::bindThreadName(std::this_thread::get_id(), "TEST");
	mlog::info("After binding the TEST value");
}

int main(int argc, char const *argv[])
{
	std::thread test(printNameTest);
	test.join();
	return 0;
}
```
Gives :
```
user$ g++  test.cpp -o main.out -pthread -std=c++11
user$ ./main.out 
[INFO    04/01/2017 13:42:56 0x7fec67a3e700] Before binding the TEST value
[INFO    04/01/2017 13:42:56 TEST] After binding the TEST value
user$
```
Assuming we have `./test.cpp` and `./logs.hpp`